### PR TITLE
LIBFCREPO-1084. Value of args.access is always a URIRef.

### DIFF
--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -148,8 +148,8 @@ class Command(BaseCommand):
             if args.member_of is not None:
                 item.member_of = URIRef(args.member_of)
             if args.access is not None:
-                item.rdf_types.add(args.access)
-                file.rdf_types.add(args.access)
+                item.rdf_type.append(args.access)
+                file.rdf_type.append(args.access)
             try:
                 with Transaction(repo) as txn:
                     try:

--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -148,9 +148,8 @@ class Command(BaseCommand):
             if args.member_of is not None:
                 item.member_of = URIRef(args.member_of)
             if args.access is not None:
-                term = uri_or_curie(args.access)
-                item.rdf_types.add(term)
-                file.rdf_types.add(term)
+                item.rdf_types.add(args.access)
+                file.rdf_types.add(args.access)
             try:
                 with Transaction(repo) as txn:
                     try:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,32 +1,67 @@
 import pytest
 
-from argparse import ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError
 from plastron.util import uri_or_curie
 from rdflib.term import URIRef
 
 
-class TestUriOrCurie:
-    # Tests for the "uri_or_curie" function
+# Tests for the "uri_or_curie" function
 
-    def test_given_None__raises_ArgumentTypeError(self):
-        with pytest.raises(ArgumentTypeError):
-            uri_or_curie(None)
+def test_given_None__raises_ArgumentTypeError():
+    with pytest.raises(ArgumentTypeError):
+        uri_or_curie(None)
 
-    def test_given_empty_string__raises_ArgumentTypeError(self):
-        with pytest.raises(ArgumentTypeError):
-            uri_or_curie('')
 
-    def test_given_invalid_curie__raises_ArgumentTypeError(self):
-        with pytest.raises(ArgumentTypeError):
-            uri_or_curie('not_in_namespace:Foo')
+def test_given_empty_string__raises_ArgumentTypeError():
+    with pytest.raises(ArgumentTypeError):
+        uri_or_curie('')
 
-    def test_given_valid_curie__returns_term(self):
-        assert uri_or_curie('umdaccess:Public') == URIRef('http://vocab.lib.umd.edu/access#Public')
 
-    def test_given_valid_N3_URI__returns_term(self):
-        assert uri_or_curie('<http://vocab.lib.umd.edu/access#Public>') == \
-            URIRef('http://vocab.lib.umd.edu/access#Public')
+def test_given_invalid_curie__raises_ArgumentTypeError():
+    with pytest.raises(ArgumentTypeError):
+        uri_or_curie('not_in_namespace:Foo')
 
-    def test_given_valid_simple_URI__returns_term(self):
-        assert uri_or_curie('http://vocab.lib.umd.edu/access#Public') == \
-            URIRef('http://vocab.lib.umd.edu/access#Public')
+
+def test_given_valid_curie__returns_term():
+    assert uri_or_curie('umdaccess:Public') == URIRef('http://vocab.lib.umd.edu/access#Public')
+
+
+def test_given_valid_N3_URI__returns_term():
+    assert uri_or_curie('<http://vocab.lib.umd.edu/access#Public>') == \
+        URIRef('http://vocab.lib.umd.edu/access#Public')
+
+
+def test_given_valid_simple_URI__returns_term():
+    assert uri_or_curie('http://vocab.lib.umd.edu/access#Public') == \
+        URIRef('http://vocab.lib.umd.edu/access#Public')
+
+
+@pytest.mark.parametrize(
+    'arg_value', [
+        # CURIE
+        'umdaccess:Public',
+        # N3-formatted URI
+        '<http://vocab.lib.umd.edu/access#Public>',
+        # plain string HTTP URI
+        'http://vocab.lib.umd.edu/access#Public'
+    ]
+)
+def test_given_valid_uri_or_curie_type__parse_args_returns_uriref(arg_value):
+    parser = ArgumentParser()
+    parser.add_argument('--access', type=uri_or_curie)
+    args = parser.parse_args(('--access', arg_value))
+    assert isinstance(args.access, URIRef)
+
+
+@pytest.mark.parametrize(
+    'arg_value', [
+        None,
+        '',
+        'not_in_namespace:Foo'
+    ]
+)
+def test_given_invalid_uri_or_curie_type__parse_args_exits(arg_value):
+    parser = ArgumentParser()
+    parser.add_argument('--access', type=uri_or_curie)
+    with pytest.raises(SystemExit):
+        parser.parse_args(('--access', arg_value))


### PR DESCRIPTION
- pytest tests do not need to be in a class
- added tests that run ArgumentParser.parse_args() and confirm that either args.access is a URIRef (for valid values) or that parse_args() raises SystemExit (for invalid values)

https://issues.umd.edu/browse/LIBFCREPO-1084